### PR TITLE
Prevent transformer failure for unsupported node type.

### DIFF
--- a/lib/src/css_mirroring/bidi_css_generator.dart
+++ b/lib/src/css_mirroring/bidi_css_generator.dart
@@ -72,11 +72,9 @@ Future<String> bidirectionalizeCss(String originalCss, CssFlipper cssFlipper,
           bufferedCommonTrans,
           bufferedNativeDirTrans,
           bufferedFlippedDirTrans);
-    } else if (entity.isDirectionInsensitiveDirective) {
+    } else {
       entity.original.remove(bufferedNativeDirTrans);
       entity.flipped.remove(bufferedFlippedDirTrans);
-    } else {
-      throw new StateError('Node type not handled: $entity');
     }
   });
   bufferedCommonTrans.commit();


### PR DESCRIPTION
Keep unsupported node types as it is instead of throwing exception.