### PR TITLE
Make use of analyzer's new resolutionMap interface.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=1.8.0 <2.0.0"
 dependencies:
   args: ">=0.12.0 <0.14.0"
-  analyzer: ">=0.27.3 <0.28.0"
+  analyzer: ^0.29.2
   barback: ^0.15.0
   bazel_worker: ^0.1.1
   csslib: ">=0.12.0 <0.14.0"


### PR DESCRIPTION
The getters in the analyzer's AST data structures will soon be changed to less specific types, so we need to use the new interface in order to avoid warnings.