### PR TITLE
Remove explicitly set Closure compiler language mode

### DIFF
--- a/lib/permutations_transformer.dart
+++ b/lib/permutations_transformer.dart
@@ -41,7 +41,7 @@ import 'package:scissors/src/utils/phase_utils.dart';
 /// 1kB / 24kB in gzipped size.
 ///
 /// cat example/permutations/build/web/main_en.js | gzip -9 | wc -c
-/// cat example/permutations/build/web/main_en.js | java -jar compiler.jar --language_in=ES5 --language_out=ES5 -O SIMPLE | gzip -9 | wc -c
+/// cat example/permutations/build/web/main_en.js | java -jar compiler.jar --language_out=ES5 -O SIMPLE | gzip -9 | wc -c
 ///
 /// This might interact with the CSS mirroring feature, in ways still TBD.
 ///

--- a/lib/src/js_optimization/closure.dart
+++ b/lib/src/js_optimization/closure.dart
@@ -20,16 +20,8 @@ import '../utils/process_utils.dart';
 
 Future<String> simpleClosureCompile(
     String javaPath, String closureCompilerJarPath, String content) async {
-  var p = await Process.start(
-      javaPath,
-      [
-        '-jar',
-        closureCompilerJarPath,
-        '--language_in=ES5',
-        '--language_out=ES5',
-        '-O',
-        'SIMPLE'
-      ],
+  var p = await Process.start(javaPath,
+      ['-jar', closureCompilerJarPath, '--language_out=ES5', '-O', 'SIMPLE'],
       mode: ProcessStartMode.DETACHED_WITH_STDIO);
 
   return successString(

--- a/lib/src/permutations/transformer.dart
+++ b/lib/src/permutations/transformer.dart
@@ -46,7 +46,7 @@ part 'settings.dart';
 /// 1kB / 24kB in gzipped size.
 ///
 /// cat example/permutations/build/web/main_en.js | gzip -9 | wc -c
-/// cat example/permutations/build/web/main_en.js | java -jar compiler.jar --language_in=ES5 --language_out=ES5 -O SIMPLE | gzip -9 | wc -c
+/// cat example/permutations/build/web/main_en.js | java -jar compiler.jar --language_out=ES5 -O SIMPLE | gzip -9 | wc -c
 ///
 /// This might interact with the CSS mirroring feature, in ways still TBD.
 ///


### PR DESCRIPTION
The Closure compiler default is now ES6 (aka EcmaScript 2015) and the
language versions will be advancing much more quickly in coming years.