### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/lib/src/image_inlining/main.dart
+++ b/lib/src/image_inlining/main.dart
@@ -49,9 +49,9 @@ main(List<String> args) async {
       (await inlineImagesWithIncludeDirs(makeFileAsset(input), includeDirs))
           .read();
   if (output.path == '-')
-    await stream.pipe(stdout);
+    await stream.cast<List<int>>().pipe(stdout);
   else
-    await stream.pipe(output.openWrite());
+    await stream.cast<List<int>>().pipe(output.openWrite());
 }
 
 Asset makeFileAsset(File file) {


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900