### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/src/css_mirroring/bidi_css_generator.dart
+++ b/lib/src/css_mirroring/bidi_css_generator.dart
@@ -13,8 +13,6 @@
 // limitations under the License.
 library scissors.src.css_mirroring.bidi_css_generator;
 
-import 'dart:async';
-
 import 'package:csslib/parser.dart' show parse;
 import 'package:csslib/visitor.dart'
     show

--- a/lib/src/css_mirroring/cssjanus_runner.dart
+++ b/lib/src/css_mirroring/cssjanus_runner.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 library scissors.src.css_mirroring.cssjanus_runner;
 
-import 'dart:async';
 import 'dart:io';
 
 import '../utils/process_utils.dart';

--- a/lib/src/css_mirroring/main.dart
+++ b/lib/src/css_mirroring/main.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';

--- a/lib/src/utils/process_utils.dart
+++ b/lib/src/utils/process_utils.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 library scissors.src.utils.process_utils;
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/path_resolver_test.dart
+++ b/test/path_resolver_test.dart
@@ -13,7 +13,6 @@
 // limitations under the License.
 library scissors.test.path_resolver_test;
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:test/test.dart';


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core